### PR TITLE
Fixed: rpm installation method.

### DIFF
--- a/group_vars/zabbix-server-mysql-standalone
+++ b/group_vars/zabbix-server-mysql-standalone
@@ -4,7 +4,7 @@
 dateTimezone: Asia/Tokyo
 
 # EPEL repository for Centos/RHEL version 7
-epelRepository: http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
+epelRepository: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 #
 # ZABBIX repository specified to use in the installation

--- a/roles/zabbix-server-mysql-standalone/tasks/install_epel.yml
+++ b/roles/zabbix-server-mysql-standalone/tasks/install_epel.yml
@@ -1,11 +1,13 @@
 ---
 # Download and install EPEL for Centos/RHEL version 7
 - name: Download EPEL Repo - Centos/RHEL 7
-  get_url: url={{ epelRepository }} dest=/tmp/epel-release-7-5.noarch.rpm
+  get_url: url={{ epelRepository }} dest=/tmp/epel-release-latest-7.noarch.rpm
   when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
- 
+
 - name: Install EPEL Repo - Centos/RHEL 7
-  command: rpm -ivh /tmp/epel-release-7-5.noarch.rpm creates=/etc/yum.repos.d/epel.repo
+  yum:
+    name: /tmp/epel-release-latest-7.noarch.rpm
+    state: present
   when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
 
 - name: Install fpint,iksemel

--- a/roles/zabbix-server-mysql-standalone/tasks/main.yml
+++ b/roles/zabbix-server-mysql-standalone/tasks/main.yml
@@ -10,7 +10,9 @@
   when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
 
 - name: Install ZABBIX Repo - Centos/RHEL 7
-  command: rpm -ivh /tmp/zabbix.rpm creates=/etc/yum.repos.d/zabbix.repo
+  yum:
+    name: /tmp/zabbix.rpm
+    state: present
   when: "ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'"
 
 - name: get {{ zabbixRpmGpgKey }}


### PR DESCRIPTION
Hi,
I made some minor improvements.
@mrnk Could you take a look at the following PR?

--- 
- `epel-release` package should not specify a specific version.
  Use `-latest` version.
- Should not use `rpm -i` command directly. Use yum module.
  http://docs.ansible.com/ansible/yum_module.html

Signed-off-by: Kazuhisa Hara <khara@sios.com>